### PR TITLE
修复地图的本地搜索功能

### DIFF
--- a/lib/EleFormBmap.vue
+++ b/lib/EleFormBmap.vue
@@ -200,4 +200,8 @@ export default {
 .highlighted .ele-form-search-location {
   color: #ddd;
 }
+
+.BMap_geolocationAddressText {
+  line-height: 32px;
+}
 </style>

--- a/lib/EleFormBmap.vue
+++ b/lib/EleFormBmap.vue
@@ -14,8 +14,8 @@
             slot="suffix"
             style="font-size:20px;margin-right:10px;"
           ></i>
-          <span class="ele-form-search-keywords">{{item.value}}&nbsp;&nbsp;</span>
-          <span class="ele-form-search-location">{{item.address}}</span>
+          <span class="ele-form-search-keywords">{{ item.value }}&nbsp;&nbsp;</span>
+          <span class="ele-form-search-location">{{ item.address }}</span>
         </div>
       </template>
     </el-autocomplete>
@@ -150,8 +150,8 @@ export default {
     },
     // 搜索结束
     handleSearchEnd (res) {
-      if (res && res.Ar && this.cb) {
-        const list = res.Ar.map((pos) => {
+      if (res && res.Ir && this.cb) {
+        const list = res.Ir.map((pos) => {
           return {
             address: pos.address,
             point: pos.point,
@@ -196,6 +196,7 @@ export default {
   font-size: 12px;
   color: #b4b4b4;
 }
+
 .highlighted .ele-form-search-location {
   color: #ddd;
 }


### PR DESCRIPTION
问题： 
vue-baidu-map返回的数据格式变了，导致该组件现在无法使用搜索功能

解决：
res.Ar 改成 res.Ir