### PR TITLE
重新修复地图的本地搜索功能

### DIFF
--- a/lib/EleFormBmap.vue
+++ b/lib/EleFormBmap.vue
@@ -150,8 +150,8 @@ export default {
     },
     // 搜索结束
     handleSearchEnd (res) {
-      if (res && res.Ar && this.cb) {
-        const list = res.Ar.map((pos) => {
+      if (res && res.Hr && this.cb) {
+        const list = res.Hr.map((pos) => {
           return {
             address: pos.address,
             point: pos.point,


### PR DESCRIPTION
问题：
vue-baidu-map返回的数据格式变了，导致该组件现在无法使用搜索功能

解决：
res.Ar 改成 res.Hr